### PR TITLE
Save Encoder/Decoder: 9x fewer allocs; 6x faster.

### DIFF
--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -176,6 +177,25 @@ func TestCustomType(t *testing.T) {
 	_ = s1.Decode("sid", encoded, dst)
 	if dst.Foo != 42 || dst.Bar != "bar" {
 		t.Fatalf("Expected %#v, got %#v", src, dst)
+	}
+}
+
+func TestDifferentCookies(t *testing.T) {
+	one := New([]byte("12345"), []byte("1234567890123456"))
+	two := New([]byte("12345"), []byte("1234567890123456"))
+
+	src := &FooBar{42, "bar"}
+
+	val, _ := one.Encode("sid", src)
+
+	dst := &FooBar{}
+	err := two.Decode("sid", val, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(dst, src) {
+		t.Fatal("not equal")
 	}
 }
 

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/gob"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -25,23 +24,12 @@ var testStrings = []string{"foo", "bar", "baz"}
 
 func TestSecureCookie(t *testing.T) {
 	// TODO test too old / too new timestamps
-	compareMaps := func(m1, m2 map[string]interface{}) error {
-		if len(m1) != len(m2) {
-			return errors.New("different maps")
-		}
-		for k, v := range m1 {
-			if m2[k] != v {
-				return fmt.Errorf("Different value for key %v: expected %v, got %v", k, m2[k], v)
-			}
-		}
-		return nil
-	}
 
 	s1 := New([]byte("12345"), []byte("1234567890123456"))
 	s2 := New([]byte("54321"), []byte("6543210987654321"))
 	value := map[string]interface{}{
 		"foo": "bar",
-		"baz": 128,
+		"baz": float64(128),
 	}
 
 	for i := 0; i < 50; i++ {
@@ -57,9 +45,14 @@ func TestSecureCookie(t *testing.T) {
 		if err2 != nil {
 			t.Fatalf("%v: %v", err2, encoded)
 		}
-		if err := compareMaps(dst, value); err != nil {
-			t.Fatalf("Expected %v, got %v.", value, dst)
+		// check map equality
+		for key, val := range value {
+			v, ok := dst[key]
+			if !ok || !reflect.DeepEqual(v, val) {
+				t.Fatalf("%v and %v not equal", v, val)
+			}
 		}
+
 		dst2 := make(map[string]interface{})
 		err3 := s2.Decode("sid", encoded, &dst2)
 		if err3 == nil {
@@ -107,13 +100,12 @@ func TestSerialization(t *testing.T) {
 		deserialized map[string]string
 		err          error
 	)
-	cookie := New([]byte("12345"), []byte("1234567890123456"))
 	for _, value := range testCookies {
-		if serialized, err = serialize(cookie, value); err != nil {
+		if serialized, err = serialize(value); err != nil {
 			t.Error(err)
 		} else {
 			deserialized = make(map[string]string)
-			if err = deserialize(cookie, serialized, &deserialized); err != nil {
+			if err = deserialize(serialized, &deserialized); err != nil {
 				t.Error(err)
 			}
 			if fmt.Sprintf("%v", deserialized) != fmt.Sprintf("%v", value) {
@@ -187,6 +179,9 @@ func TestDifferentCookies(t *testing.T) {
 	src := &FooBar{42, "bar"}
 
 	val, _ := one.Encode("sid", src)
+
+	// then do it again
+	val, _ = one.Encode("sid", src)
 
 	dst := &FooBar{}
 	err := two.Decode("sid", val, dst)

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -100,19 +100,19 @@ func TestEncription(t *testing.T) {
 	}
 }
 
-/*
 func TestSerialization(t *testing.T) {
 	var (
 		serialized   []byte
 		deserialized map[string]string
 		err          error
 	)
+	cookie := New([]byte("12345"), []byte("1234567890123456"))
 	for _, value := range testCookies {
-		if serialized, err = serialize(value); err != nil {
+		if serialized, err = serialize(cookie, value); err != nil {
 			t.Error(err)
 		} else {
 			deserialized = make(map[string]string)
-			if err = deserialize(serialized, &deserialized); err != nil {
+			if err = deserialize(cookie, serialized, &deserialized); err != nil {
 				t.Error(err)
 			}
 			if fmt.Sprintf("%v", deserialized) != fmt.Sprintf("%v", value) {
@@ -120,7 +120,7 @@ func TestSerialization(t *testing.T) {
 			}
 		}
 	}
-}*/
+}
 
 func TestEncoding(t *testing.T) {
 	for _, value := range testStrings {

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/aes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"strings"
@@ -174,5 +175,20 @@ func TestCustomType(t *testing.T) {
 	_ = s1.Decode("sid", encoded, dst)
 	if dst.Foo != 42 || dst.Bar != "bar" {
 		t.Fatalf("Expected %#v, got %#v", src, dst)
+	}
+}
+
+func BenchmarkRoundtrip(b *testing.B) {
+	cook := New([]byte("12345"), []byte("1234567890123456"))
+
+	src := &FooBar{42, "bar"}
+	gob.Register(src)
+
+	var val string
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		val, _ = cook.Encode("sid", src)
+		_ = cook.Decode("sid", val, src)
 	}
 }


### PR DESCRIPTION
This PR is meant to address performance and allocation overhead. Per the `gob/encoding` documentation: 

> "...[it] is most efficient when a single Encoder is used to transmit a stream of values, amortizing the cost of compilation."

The existing implementation created and destroyed `gob.Encoders` and `gob.Decoders` on every call to `serialize` and `deserialize`, respectively.

I changed the `SecureCookie` object to maintain a buffer, encoder, and decoder to re-use. There is a significant difference in speed and memory allocation overhead:

| Implementation | time/op | mem/op | allocs/op | 
| --------------------- |:----------:|:-----------:|:-------------:|
| Old | 75,275 ns | 21,396 B | 369 |
| New | 17,843 ns | 3,475 B | 39 |

(I've added the benchmark in the testing file for you to see for yourself.)

The downside here is that the `SecureCookie` object has to lock around serialization calls. This could potentially be improved by maintaining an array of buffers and doing fine-grained locking. (But then we would have a *really* fat struct.)

Looking forward to your comments,
Phil

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gorilla/securecookie/10)
<!-- Reviewable:end -->
