### PR TITLE
say that we create a key of a certain length, not strength

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -340,9 +340,9 @@ func decode(value []byte) ([]byte, error) {
 
 // Helpers --------------------------------------------------------------------
 
-// GenerateRandomKey creates a random key with the given strength.
-func GenerateRandomKey(strength int) []byte {
-	k := make([]byte, strength)
+// GenerateRandomKey creates a random key with the given length in bytes.
+func GenerateRandomKey(length int) []byte {
+	k := make([]byte, length)
 	if _, err := io.ReadFull(rand.Reader, k); err != nil {
 		return nil
 	}


### PR DESCRIPTION
This is a simple documentation change. 

When I looked at the documentation of `GenerateRandomKey` for the first time, I had no idea what was meant by "strength" and had to actually look at the implementation to confirm that it really just generated a key of a certain length, instead of using some different form of key generation with a different strength metric.
