### PR TITLE
Improve Decode against timing attacks

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -177,7 +177,12 @@ func (s *SecureCookie) Encode(name string, value interface{}) (string, error) {
 // it was stored. The value argument is the encoded cookie value. The dst
 // argument is where the cookie will be decoded. It must be a pointer.
 func (s *SecureCookie) Decode(name, value string, dst interface{}) error {
+	// retErr is the error which will be returned.
+	// It will be the first error that will occur (if any).
 	var retErr error
+
+	// setErr saves the error only if there was no previous error.
+	// Otherwise retErr would be overwritten by subsequent errors.
 	setErr := func(err error) {
 		if retErr == nil {
 			retErr = err

--- a/securecookie.go
+++ b/securecookie.go
@@ -375,11 +375,11 @@ func EncodeMulti(name string, value interface{}, codecs ...Codec) (string, error
 
 	var errors MultiError
 	for _, codec := range codecs {
-		if encoded, err := codec.Encode(name, value); err == nil {
+		encoded, err := codec.Encode(name, value)
+		if err == nil {
 			return encoded, nil
-		} else {
-			errors = append(errors, err)
 		}
+		errors = append(errors, err)
 	}
 	return "", errors
 }
@@ -395,11 +395,11 @@ func DecodeMulti(name string, value string, dst interface{}, codecs ...Codec) er
 
 	var errors MultiError
 	for _, codec := range codecs {
-		if err := codec.Decode(name, value, dst); err == nil {
+		err := codec.Decode(name, value, dst)
+		if err == nil {
 			return nil
-		} else {
-			errors = append(errors, err)
 		}
+		errors = append(errors, err)
 	}
 	return errors
 }

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -157,6 +157,16 @@ func TestMultiNoCodecs(t *testing.T) {
 	}
 }
 
+func TestMissingKey(t *testing.T) {
+	s1 := New(nil, nil)
+
+	var dst []byte
+	err := s1.Decode("sid", "value", &dst)
+	if err != errHashKeyNotSet {
+		t.Fatalf("Expected %#v, got %#v", errHashKeyNotSet, err)
+	}
+}
+
 // ----------------------------------------------------------------------------
 
 type FooBar struct {


### PR DESCRIPTION
The current implementation of Decode allows very easily with timing attacks to find out which error occurred. I improved it, but there are probably still some room for improvement.