### PR TITLE
Removed redundant calls to len()

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -255,7 +255,7 @@ func createMac(h hash.Hash, value []byte) []byte {
 // verifyMac verifies that a message authentication code (MAC) is valid.
 func verifyMac(h hash.Hash, value []byte, mac []byte) error {
 	mac2 := createMac(h, value)
-	if len(mac) == len(mac2) && subtle.ConstantTimeCompare(mac, mac2) == 1 {
+	if subtle.ConstantTimeCompare(mac, mac2) == 1 {
 		return nil
 	}
 	return ErrMacInvalid


### PR DESCRIPTION
subtle.ConstantTimeCompare already undertakes a length check internally: http://golang.org/src/crypto/subtle/constant_time.go?s=490:531#L2

```
func ConstantTimeCompare(x, y []byte) int {
    13		if len(x) != len(y) {
    14			return 0
    15		}
    16	
```

Not a major change, but was low hanging fruit and cleaner code paths are always good!