### PR TITLE
Fix panic when decode succeeds but MAC is invalid

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -214,6 +214,8 @@ func (s *SecureCookie) Decode(name, value string, dst interface{}) error {
 	parts := bytes.SplitN(b, []byte("|"), 3)
 	if len(parts) != 3 {
 		setErr(ErrMacInvalid)
+		// Dummy parts to avoid panic
+		parts = make([][]byte, 3)
 	}
 	h := hmac.New(s.hashFunc, s.hashKey)
 	b = append([]byte(name+"|"), b[:len(b)-len(parts[2])-1]...)

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -167,6 +167,16 @@ func TestMissingKey(t *testing.T) {
 	}
 }
 
+func TestInvalidKey(t *testing.T) {
+	s1 := New(nil, nil)
+
+	var dst []byte
+	err := s1.Decode("sid", "H4X0RD-VALUE", &dst)
+	if err != errHashKeyNotSet {
+		t.Fatalf("Expected %#v, got %#v", errHashKeyNotSet, err)
+	}
+}
+
 // ----------------------------------------------------------------------------
 
 type FooBar struct {


### PR DESCRIPTION
When key is successfully decoded, but nevertheless, is an invalid MAC, `bytes.SplitN` fails and panics. Fix and tests included.
 