### PR TITLE
Added support for encoding/json

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -177,71 +177,60 @@ func (s *SecureCookie) Encode(name string, value interface{}) (string, error) {
 // it was stored. The value argument is the encoded cookie value. The dst
 // argument is where the cookie will be decoded. It must be a pointer.
 func (s *SecureCookie) Decode(name, value string, dst interface{}) error {
-	var retErr error
-	setErr := func(err error) {
-		if retErr == nil {
-			retErr = err
-		}
-	}
-
 	if s.err != nil {
-		setErr(s.err)
+		return s.err
 	}
 	if s.hashKey == nil {
 		s.err = errHashKeyNotSet
-		setErr(s.err)
+		return s.err
 	}
 	// 1. Check length.
 	if s.maxLength != 0 && len(value) > s.maxLength {
-		setErr(errors.New("securecookie: the value is too long"))
+		return errors.New("securecookie: the value is too long")
 	}
 	// 2. Decode from base64.
 	b, err := decode([]byte(value))
 	if err != nil {
-		setErr(err)
-		// Dummy b to avoid errors
-		b = []byte("||")
+		return err
 	}
 	// 3. Verify MAC. Value is "date|value|mac".
 	parts := bytes.SplitN(b, []byte("|"), 3)
 	if len(parts) != 3 {
-		setErr(ErrMacInvalid)
+		return ErrMacInvalid
 	}
 	h := hmac.New(s.hashFunc, s.hashKey)
 	b = append([]byte(name+"|"), b[:len(b)-len(parts[2])-1]...)
 	if err = verifyMac(h, b, parts[2]); err != nil {
-		setErr(err)
+		return err
 	}
 	// 4. Verify date ranges.
 	var t1 int64
 	if t1, err = strconv.ParseInt(string(parts[0]), 10, 64); err != nil {
-		setErr(errors.New("securecookie: invalid timestamp"))
+		return errors.New("securecookie: invalid timestamp")
 	}
 	t2 := s.timestamp()
 	if s.minAge != 0 && t1 > t2-s.minAge {
-		setErr(errors.New("securecookie: timestamp is too new"))
+		return errors.New("securecookie: timestamp is too new")
 	}
 	if s.maxAge != 0 && t1 < t2-s.maxAge {
-		setErr(errors.New("securecookie: expired timestamp"))
+		return errors.New("securecookie: expired timestamp")
 	}
 	// 5. Decrypt (optional).
 	b, err = decode(parts[1])
 	if err != nil {
-		setErr(err)
+		return err
 	}
 	if s.block != nil {
 		if b, err = decrypt(s.block, b); err != nil {
-			setErr(err)
+			return err
 		}
 	}
-
-	// Check for errors before deserialization to avoid unwanted side effects
-	if retErr != nil {
-		return retErr
-	}
-
 	// 6. Deserialize.
-	return deserialize(b, dst)
+	if err = deserialize(b, dst); err != nil {
+		return err
+	}
+	// Done.
+	return nil
 }
 
 // timestamp returns the current timestamp, in seconds.

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/aes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -62,6 +63,27 @@ func TestSecureCookie(t *testing.T) {
 		err3 := s2.Decode("sid", encoded, &dst2)
 		if err3 == nil {
 			t.Fatalf("Expected failure decoding.")
+		}
+	}
+}
+
+func TestDecodeInvalid(t *testing.T) {
+	// List of invalid cookies, which must not be accepted, base64-decoded
+	// (they will be encoded before passing to Decode).
+	invalidCookies := []string{
+		"",
+		" ",
+		"\n",
+		"||",
+		"|||",
+		"cookie",
+	}
+	s := New([]byte("12345"), nil)
+	var dst string
+	for i, v := range invalidCookies {
+		err := s.Decode("name", base64.StdEncoding.EncodeToString([]byte(v)), &dst)
+		if err == nil {
+			t.Fatalf("%d: expected failure decoding", i)
 		}
 	}
 }

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -101,7 +101,7 @@ func TestAuthentication(t *testing.T) {
 	}
 }
 
-func TestEncription(t *testing.T) {
+func TestEncryption(t *testing.T) {
 	block, err := aes.NewCipher([]byte("1234567890123456"))
 	if err != nil {
 		t.Fatalf("Block could not be created")
@@ -121,18 +121,41 @@ func TestEncription(t *testing.T) {
 	}
 }
 
-func TestSerialization(t *testing.T) {
+func TestGobSerialization(t *testing.T) {
 	var (
+		sz           GobEncoder
 		serialized   []byte
 		deserialized map[string]string
 		err          error
 	)
 	for _, value := range testCookies {
-		if serialized, err = serialize(value); err != nil {
+		if serialized, err = sz.Serialize(value); err != nil {
 			t.Error(err)
 		} else {
 			deserialized = make(map[string]string)
-			if err = deserialize(serialized, &deserialized); err != nil {
+			if err = sz.Deserialize(serialized, &deserialized); err != nil {
+				t.Error(err)
+			}
+			if fmt.Sprintf("%v", deserialized) != fmt.Sprintf("%v", value) {
+				t.Errorf("Expected %v, got %v.", value, deserialized)
+			}
+		}
+	}
+}
+
+func TestJSONSerialization(t *testing.T) {
+	var (
+		sz           JSONEncoder
+		serialized   []byte
+		deserialized map[string]string
+		err          error
+	)
+	for _, value := range testCookies {
+		if serialized, err = sz.Serialize(value); err != nil {
+			t.Error(err)
+		} else {
+			deserialized = make(map[string]string)
+			if err = sz.Deserialize(serialized, &deserialized); err != nil {
 				t.Error(err)
 			}
 			if fmt.Sprintf("%v", deserialized) != fmt.Sprintf("%v", value) {


### PR DESCRIPTION
Added a new `Encoder` interface with `serialize` and `deserialize` methods. The existing `encoding/gob` remains the default for compatibility reasons. Package users who wish to use the (often faster) `encoding/json` package can do so at the cost of some extra LOC for custom types.

At the moment the interface and its methods are private as I wanted to avoid expanding the public API too much. If there's a desire to have it public so that others can satisfy `Encoder` in their own code then I'm happy to change it.

I also added a new JSON test based on the existing gob test for completeness.