### PR TITLE
Use reflect.DeepEqual instead

### DIFF
--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -9,8 +9,8 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -24,18 +24,6 @@ var testStrings = []string{"foo", "bar", "baz"}
 
 func TestSecureCookie(t *testing.T) {
 	// TODO test too old / too new timestamps
-	compareMaps := func(m1, m2 map[string]interface{}) error {
-		if len(m1) != len(m2) {
-			return errors.New("different maps")
-		}
-		for k, v := range m1 {
-			if m2[k] != v {
-				return fmt.Errorf("Different value for key %v: expected %v, got %v", k, m2[k], v)
-			}
-		}
-		return nil
-	}
-
 	s1 := New([]byte("12345"), []byte("1234567890123456"))
 	s2 := New([]byte("54321"), []byte("6543210987654321"))
 	value := map[string]interface{}{
@@ -56,7 +44,7 @@ func TestSecureCookie(t *testing.T) {
 		if err2 != nil {
 			t.Fatalf("%v: %v", err2, encoded)
 		}
-		if err := compareMaps(dst, value); err != nil {
+		if !reflect.DeepEqual(dst, value) {
 			t.Fatalf("Expected %v, got %v.", value, dst)
 		}
 		dst2 := make(map[string]interface{})


### PR DESCRIPTION
Unless there's something I'm missing, probably better to
delegate this check to the reflect package.