### PR TITLE
Exposing the cookie timestamp

### DIFF
--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -272,3 +272,15 @@ func TestCustomType(t *testing.T) {
 		t.Fatalf("Expected %#v, got %#v", src, dst)
 	}
 }
+
+func TestLastTimestamp(t *testing.T) {
+	var v, tt int64 = 1234, 4567
+	s1 := New([]byte("12345"), []byte("1234567890123456"))
+	s1.timeFunc = func() int64 { return tt }
+
+	encoded, _ := s1.Encode("sid", v)
+	s1.Decode("sid", encoded, v)
+	if s1.LastTimestamp != tt {
+		t.Fatalf("Expected %v, got %v", tt, s1.LastTimestamp)
+	}
+}


### PR DESCRIPTION
I have a use case where I want to refresh the cookie and its data after a certain time period. This period is much shorter than the maximum age of the cookie and the cookie's validity shouldn't be affected by this shorter refresh cycle.

I could include a timestamp inside my cookie data, but that seems highly redundant as there is already a HMAC verified timestamp in the cookie and I would rather save some bandwidth. Unfortunately this timestamp isn't exposed in any way currently, so this is where my patch comes in.

An additional return value from the `Decode` method would be the safest & most straightforward solution. It would break API compatibility however, so probably not that likely to get merged.

I gathered from issue #14 that thread safety isn't a goal of this library. This opened up another fairly easy solution, which I have implemented. Successful enough calls to `Decode` will update the new `LastTimestamp` property of the main `SecureCookie` struct instance with the cookie's timestamp.