### PR TITLE
[feature] NopEncoder: accept/return []byte.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package gorilla/securecookie encodes and decodes authenticated and optionally
+Package securecookie encodes and decodes authenticated and optionally
 encrypted cookie values.
 
 Secure cookies can't be forged, because their values are validated using HMAC.


### PR DESCRIPTION
**This is a WIP (don't merge).**

* This is a simple 'encoder' that accepts an `interface{}` to satisfy the `securecookie.Serializer` interface, and returns `input.([]byte)` with no further serialization.

The name is a riff on https://golang.org/pkg/io/ioutil/#NopCloser