### PR TITLE
Update Readme: Added HttpOnly, Secure flags for setting the cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ func SetCookieHandler(w http.ResponseWriter, r *http.Request) {
 			Name:  "cookie-name",
 			Value: encoded,
 			Path:  "/",
+			Secure: true,
+			HttpOnly: true,
 		}
 		http.SetCookie(w, cookie)
 	}


### PR DESCRIPTION
Since people tend to copy paste and you also recommend to use HTTPS: It should be enforced when setting the cookie. I just updated the sample in the README.