### PR TITLE
fix New not checking for an empty hashKey

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -141,7 +141,7 @@ func New(hashKey, blockKey []byte) *SecureCookie {
 		maxLength: 4096,
 		sz:        GobEncoder{},
 	}
-	if hashKey == nil {
+	if len(hashKey) == 0 {
 		s.err = errHashKeyNotSet
 	}
 	if blockKey != nil {

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -268,15 +268,22 @@ func TestMultiNoCodecs(t *testing.T) {
 }
 
 func TestMissingKey(t *testing.T) {
-	s1 := New(nil, nil)
-
-	var dst []byte
-	err := s1.Decode("sid", "value", &dst)
-	if err != errHashKeyNotSet {
-		t.Fatalf("Expected %#v, got %#v", errHashKeyNotSet, err)
+	emptyKeys := [][]byte{
+		nil,
+		[]byte(""),
 	}
-	if err2, ok := err.(Error); !ok || !err2.IsUsage() {
-		t.Errorf("Expected missing hash key to be IsUsage(); was %#v", err)
+
+	for _, key := range emptyKeys {
+		s1 := New(key, nil)
+
+		var dst []byte
+		err := s1.Decode("sid", "value", &dst)
+		if err != errHashKeyNotSet {
+			t.Fatalf("Expected %#v, got %#v", errHashKeyNotSet, err)
+		}
+		if err2, ok := err.(Error); !ok || !err2.IsUsage() {
+			t.Errorf("Expected missing hash key to be IsUsage(); was %#v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
this scenario might occur when converting from an empty string to
byte slice, such as when reading from a configuration file.