### PR TITLE
github: remove false-match for language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+fuzz/corpus/*.sc linguist-detectable=false


### PR DESCRIPTION
This fixes the language detection on Github, falsely inferring that over 50% of this codebase is in Scala. Not a major issue, but it caught me off guard at first!

![image](https://user-images.githubusercontent.com/7517515/46753806-0d8ba000-cc7e-11e8-86e7-1ebc1a972df6.png)
