### PR TITLE
add more compact encoding

### DIFF
--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -45,7 +45,7 @@ func TestSecureCookie(t *testing.T) {
 			t.Error(err1)
 			continue
 		}
-		t.Log("i", i, "len", len(encoded))
+		t.Log("i", i, "len", len(encoded), "c", encoded)
 		dst := make(map[string]interface{})
 		err2 := s1.Decode("sid", encoded, &dst)
 		if err2 != nil {


### PR DESCRIPTION
Current encoding does Base64 twice against payload because of intermediate
text encoding. And it produces too large mac (256bit) while 128bit is more
than enough.

Add "compact" mode which uses binary encoding for message with single
Base64 pass and 128bit hmac output (at max).

```
    TestSecureCookie: securecookie_test.go:48: i 0 len 184                                                         
    TestSecureCookie: securecookie_test.go:48: i 1 len 128                                                         
    TestSecureCookie: securecookie_test.go:48: i 2 len 188                                                         
    TestSecureCookie: securecookie_test.go:48: i 3 len 128                                                         
    TestSecureCookie: securecookie_test.go:48: i 4 len 188                                                         
    TestSecureCookie: securecookie_test.go:48: i 5 len 128                                                         
    TestSecureCookie: securecookie_test.go:48: i 6 len 188                                                         
    TestSecureCookie: securecookie_test.go:48: i 7 len 128                                                         
    TestSecureCookie: securecookie_test.go:48: i 8 len 188                                                         
    TestSecureCookie: securecookie_test.go:48: i 9 len 128                                                         
```