### PR TITLE
GenerateRandomKey: do not swallow errors

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -510,12 +510,12 @@ func decode(value []byte) ([]byte, error) {
 // persisted. New keys will be created when the application is restarted, and
 // previously issued cookies will not be able to be decoded.
 //
-// Callers should explicitly check for the possibility of a nil return, treat
-// it as a failure of the system random number generator, and not continue.
+// Panics if the system random number generator cannot come up with the requested
+// amount of randomness.
 func GenerateRandomKey(length int) []byte {
 	k := make([]byte, length)
 	if _, err := io.ReadFull(rand.Reader, k); err != nil {
-		return nil
+		panic(fmt.Sprintf("could not generate %d bytes of randomness: %s", length, err.Error()))
 	}
 	return k
 }


### PR DESCRIPTION
This is a bugfix; `make verify` and `make test` are passing.

The requirement to check for nil returns from GenerateRandomKey is so unexpected that even other Gorilla libraries get it wrong:

<https://github.com/gorilla/sessions/blob/3eed1c4ffcde6f23b6f88068c63c1ef6190df331/store.go#L225>

Since a malfunction of the system random number generator is pretty unrecoverable for most security-sensitive applications, I consider it fine to use a panic here. #84 suggests to fix this by changing the interface, but most callers will have no better option than to just die anyway. If callers need a more specific behavior, they can implement these three lines of code themselves with application-specific error handling.